### PR TITLE
Enhance hook script

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,26 +8,30 @@ A custom build of [ZFSBootMenu](https://zfsbootmenu.org) to allow unlocking and 
 
 2. Clone the current repository
 
-3. Fetch the latest zbm-builder.sh script from ZFSBootMenu repository
+3.(optionally) Add the partitons' UUIDs to dracut.conf.d/zfsbootmenu-luks-uuids.conf
+
+4. Fetch the latest zbm-builder.sh script from ZFSBootMenu repository
 
     ```
     curl -O https://raw.githubusercontent.com/zbm-dev/zfsbootmenu/master/zbm-builder.sh
     ```
 
-4. Build a custom ZFSBootMenu image by using current repository as a build directory
+5. Build a custom ZFSBootMenu image by using current repository as a build directory
 
     ```
     cd zbm-luks-unlock
     ./zbm-builder.sh -H
     ```
 
-5. The newly built ZFSBootMenu image will reside in the `build` directory
+6. The newly built ZFSBootMenu image will reside in the `build` directory
 
 ## How it works
 
 The hooks mechanism of ZFSBootMenu is used to inject two hooks into the boot process.
 
-First is the `luks-unlock.sh` early-setup hook that prompts the user for the passphrase that unlocks the luks volumes.
+First is the `luks-unlock.sh` early-setup hook that prompts the user for the passphrase that unlocks the luks volumes either 
+specified via their UUIDs in dracut.conf.d/zfsbootmenu-luks-uuids.conf or, if this file is empty, then tries to unlock all 
+luks partitons that are found.
 This allows ZFSBootMenu to discover zfs pools residing in luks volumes. The passphrase is also stored a relevant keyfile
 in memory to be used by the later hooks.
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A custom build of [ZFSBootMenu](https://zfsbootmenu.org) to allow unlocking and 
 
 2. Clone the current repository
 
-3.(optionally) Add the partitons' UUIDs to dracut.conf.d/zfsbootmenu-luks-uuids.conf
+3. (optionally) Add the partitons' UUIDs to dracut.conf.d/zfsbootmenu-luks-uuids.conf
 
 4. Fetch the latest zbm-builder.sh script from ZFSBootMenu repository
 

--- a/dracut.conf.d/99-crypt.conf
+++ b/dracut.conf.d/99-crypt.conf
@@ -1,3 +1,4 @@
 add_dracutmodules+=" crypt "
 add_drivers+=" dm-crypt "
 install_optional_items+=" cryptsetup cpio find truncate "
+install_items+=" /etc/zfsbootmenu-luks-uuids.conf "

--- a/dracut.conf.d/99-crypt.conf
+++ b/dracut.conf.d/99-crypt.conf
@@ -1,4 +1,4 @@
 add_dracutmodules+=" crypt "
 add_drivers+=" dm-crypt "
 install_optional_items+=" cryptsetup cpio find truncate "
-install_items+=" /etc/zfsbootmenu-luks-uuids.conf "
+install_items+=" /etc/zfsbootmenu/dracut.conf.d/zfsbootmenu-luks-uuids.conf "

--- a/dracut.conf.d/zfsbootmenu-luks-uuids.conf
+++ b/dracut.conf.d/zfsbootmenu-luks-uuids.conf
@@ -1,0 +1,2 @@
+# This file is used to specify the UUIDs that should be unlocked before ZFSBootMenu is launched
+# 550e8400-e29b-11d4-a716-446655440000

--- a/hooks/early-setup.d/luks-unlock.sh
+++ b/hooks/early-setup.d/luks-unlock.sh
@@ -28,7 +28,7 @@
 ## Because this script is intended to unlock volumes *before* ZFSBootMenu
 ## imports ZFS pools, it should be run as an early hook.
 
-UUID_CONF="/etc/zfsbootmenu-luks-uuids.conf"
+UUID_CONF="/etc/zfsbootmenu/dracut.conf.d/zfsbootmenu-luks-uuids.conf"
 
 sources=(
   /lib/profiling-lib.sh


### PR DESCRIPTION
The hook script has been enhanced to allow for a config file to be specified, which defines the partitions to be unlocked via their UUIDs. This allows to have further luks encrypted devices/partitons with different keys, which may not be relevant for zfsbootmenu to unlock the root partiton. 
If the specified config file is not existing or is empty, then the hook script will fall back to it's original behaviour.